### PR TITLE
fix: Fixing ISSUE-18 where writing to a closed channel causes a panic

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -133,7 +133,7 @@ func (c *Conn) Write(message *Message, content *[]byte) error {
 	binary.BigEndian.PutUint64(encodedMessage[protocol.ContentLengthV0Offset:protocol.ContentLengthV0Offset+protocol.ContentLengthV0Size], message.ContentLength)
 
 	c.Lock()
-	if c.state.Load() != CONNECTED 	{
+	if c.state.Load() != CONNECTED {
 		c.Unlock()
 		return c.Error()
 	}

--- a/conn.go
+++ b/conn.go
@@ -132,11 +132,12 @@ func (c *Conn) Write(message *Message, content *[]byte) error {
 	binary.BigEndian.PutUint32(encodedMessage[protocol.OperationV0Offset:protocol.OperationV0Offset+protocol.OperationV0Size], message.Operation+c.offset)
 	binary.BigEndian.PutUint64(encodedMessage[protocol.ContentLengthV0Offset:protocol.ContentLengthV0Offset+protocol.ContentLengthV0Size], message.ContentLength)
 
-	if c.state.Load() != CONNECTED {
+	c.Lock()
+	if c.state.Load() != CONNECTED 	{
+		c.Unlock()
 		return c.Error()
 	}
 
-	c.Lock()
 	_, err := c.writer.Write(encodedMessage[:])
 	if err != nil {
 		c.Unlock()


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue has been fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

By locking the writer before checking the connection state we're able to guarantee the flusher is not closed before we write to it. 

Fixes https://github.com/Loophole-Labs/frisbee/issues/18

## Type of change

Please update the title of this PR to reflect the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Please make sure that existing test cases pass (with `go test ./... -race` and `go test -bench=. ./... -race`), 
and if required please add new test cases and list them below:

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:
```shell
❯ go test -bench=. ./...
goos: darwin
goarch: amd64
pkg: github.com/loophole-labs/frisbee
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkClientThroughput/test-16                     40          30809095 ns/op
BenchmarkClientThroughputResponse/test-16                     37          31593497 ns/op
BenchmarkThroughputPipe32-16                                  50          23348719 ns/op
BenchmarkThroughputPipe512-16                                 30          36660986 ns/op
BenchmarkThroughputNetwork32-16                               52          21141169 ns/op
BenchmarkThroughputNetwork512-16                              34          32617784 ns/op
BenchmarkThroughputNetwork1024-16                             25          47693568 ns/op
BenchmarkThroughputNetwork2048-16                             15          72436898 ns/op
BenchmarkThroughputNetwork4096-16                              8         128761782 ns/op
BenchmarkThroughputNetwork1mb-16                             420           2875763 ns/op
BenchmarkThroughput/test-16                                   36          34597223 ns/op
BenchmarkThroughputWithResponse/test-16                       33          34437061 ns/op
PASS
ok      github.com/loophole-labs/frisbee        16.489s
?       github.com/loophole-labs/frisbee/internal/errors        [no test files]
goos: darwin
goarch: amd64
pkg: github.com/loophole-labs/frisbee/internal/protocol
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkEncodeHandler-16               69696060                14.45 ns/op
BenchmarkDecodeHandler-16               100000000               10.78 ns/op
BenchmarkEncodeDecodeHandler-16         42110547                26.94 ns/op
BenchmarkEncode-16                      75824376                13.97 ns/op
BenchmarkDecode-16                      158862639                7.412 ns/op
BenchmarkEncodeDecode-16                46556433                23.89 ns/op
PASS
ok      github.com/loophole-labs/frisbee/internal/protocol      7.558s
PASS
ok      github.com/loophole-labs/frisbee/internal/ringbuffer    0.114s
```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `go fmt ./...` has been run
- [x] `golangci-lint run --skip-dirs-use-default` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
