### PR TITLE
feat: (LOOP-91) improving write efficiency of frisbee.Conn

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -133,7 +133,7 @@ func (c *Conn) Write(message *Message, content *[]byte) error {
 
 	var temp [protocol.MessageV0Size]byte
 
-	if protocol.MessageV0Size > 1<<19 - c.writeBufferSize {
+	if protocol.MessageV0Size > 1<<19-c.writeBufferSize {
 		binary.BigEndian.PutUint16(temp[protocol.VersionV0Offset:protocol.VersionV0Offset+protocol.VersionV0Size], protocol.Version0)
 		binary.BigEndian.PutUint32(temp[protocol.FromV0Offset:protocol.FromV0Offset+protocol.FromV0Size], message.From)
 		binary.BigEndian.PutUint32(temp[protocol.ToV0Offset:protocol.ToV0Offset+protocol.ToV0Size], message.To)
@@ -171,7 +171,7 @@ func (c *Conn) Write(message *Message, content *[]byte) error {
 		c.writeBufferSize += protocol.MessageV0Size
 	}
 	if content != nil {
-		if message.ContentLength > 1 << 19 - c.writeBufferSize {
+		if message.ContentLength > 1<<19-c.writeBufferSize {
 			var n uint64
 			for n < message.ContentLength {
 				nn := uint64(copy(c.writeBuffer[c.writeBufferSize:], (*content)[n:]))

--- a/conn.go
+++ b/conn.go
@@ -141,7 +141,7 @@ func (c *Conn) Write(message *Message, content *[]byte) error {
 		binary.BigEndian.PutUint32(encodedMessage[protocol.OperationV0Offset:protocol.OperationV0Offset+protocol.OperationV0Size], message.Operation+c.offset)
 		binary.BigEndian.PutUint64(encodedMessage[protocol.ContentLengthV0Offset:protocol.ContentLengthV0Offset+protocol.ContentLengthV0Size], message.ContentLength)
 		if c.writeBufferSize > 0 {
-			if message.ContentLength > 0 {
+			if content != nil {
 				n, err := c.conn.Write(append(c.writeBuffer[:c.writeBufferSize], append(encodedMessage[:], *content...)...))
 				if err != nil {
 					c.Unlock()
@@ -188,7 +188,7 @@ func (c *Conn) Write(message *Message, content *[]byte) error {
 			}
 			c.writeBufferSize = 0
 		} else {
-			if message.ContentLength > 0 {
+			if content != nil {
 				n, err := c.conn.Write(append(encodedMessage[:], *content...))
 				if err != nil {
 					c.Unlock()
@@ -248,7 +248,7 @@ func (c *Conn) Write(message *Message, content *[]byte) error {
 		binary.BigEndian.PutUint32(c.writeBuffer[c.writeBufferSize+protocol.OperationV0Offset:c.writeBufferSize+protocol.OperationV0Offset+protocol.OperationV0Size], message.Operation+c.offset)
 		binary.BigEndian.PutUint64(c.writeBuffer[c.writeBufferSize+protocol.ContentLengthV0Offset:c.writeBufferSize+protocol.ContentLengthV0Offset+protocol.ContentLengthV0Size], message.ContentLength)
 		c.writeBufferSize += protocol.MessageV0Size
-		if message.ContentLength > 0 {
+		if content != nil {
 			copy(c.writeBuffer[c.writeBufferSize:], *content)
 			c.writeBufferSize += message.ContentLength
 		}

--- a/conn.go
+++ b/conn.go
@@ -17,7 +17,6 @@
 package frisbee
 
 import (
-	"bufio"
 	"encoding/binary"
 	"github.com/loophole-labs/frisbee/internal/errors"
 	"github.com/loophole-labs/frisbee/internal/protocol"
@@ -55,7 +54,8 @@ type Conn struct {
 	sync.Mutex
 	conn             net.Conn
 	state            *atomic.Int32
-	writer           *bufio.Writer
+	writeBuffer      []byte
+	writeBufferSize  uint64
 	flusher          chan struct{}
 	incomingMessages *ringbuffer.RingBuffer
 	logger           *zerolog.Logger
@@ -81,7 +81,7 @@ func New(c net.Conn, l *zerolog.Logger, offset uint32) (conn *Conn) {
 	conn = &Conn{
 		conn:             c,
 		state:            atomic.NewInt32(CONNECTED),
-		writer:           bufio.NewWriterSize(c, 1<<19),
+		writeBuffer:      make([]byte, 1<<19),
 		incomingMessages: ringbuffer.NewRingBuffer(1 << 19),
 		flusher:          make(chan struct{}, 1024),
 		logger:           l,
@@ -121,16 +121,11 @@ func (c *Conn) Offset() uint32 {
 func (c *Conn) Write(message *Message, content *[]byte) error {
 	if content != nil && int(message.ContentLength) != len(*content) {
 		return InvalidContentLength
+	} else if message.ContentLength > 0 && content == nil {
+		return InvalidContentLength
 	}
 
 	var encodedMessage [protocol.MessageV0Size]byte
-
-	binary.BigEndian.PutUint16(encodedMessage[protocol.VersionV0Offset:protocol.VersionV0Offset+protocol.VersionV0Size], protocol.Version0)
-	binary.BigEndian.PutUint32(encodedMessage[protocol.FromV0Offset:protocol.FromV0Offset+protocol.FromV0Size], message.From)
-	binary.BigEndian.PutUint32(encodedMessage[protocol.ToV0Offset:protocol.ToV0Offset+protocol.ToV0Size], message.To)
-	binary.BigEndian.PutUint32(encodedMessage[protocol.IdV0Offset:protocol.IdV0Offset+protocol.IdV0Size], message.Id)
-	binary.BigEndian.PutUint32(encodedMessage[protocol.OperationV0Offset:protocol.OperationV0Offset+protocol.OperationV0Size], message.Operation+c.offset)
-	binary.BigEndian.PutUint64(encodedMessage[protocol.ContentLengthV0Offset:protocol.ContentLengthV0Offset+protocol.ContentLengthV0Size], message.ContentLength)
 
 	c.Lock()
 	if c.state.Load() != CONNECTED {
@@ -138,53 +133,152 @@ func (c *Conn) Write(message *Message, content *[]byte) error {
 		return c.Error()
 	}
 
-	_, err := c.writer.Write(encodedMessage[:])
-	if err != nil {
-		c.Unlock()
-		if c.state.Load() != CONNECTED {
-			err = c.Error()
-			c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
-			return errors.WithContext(err, WRITE)
-		}
-		c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
-		return c.closeWithError(err)
-	}
-	if content != nil {
-		_, err = c.writer.Write(*content)
-		if err != nil {
-			c.Unlock()
-			if c.state.Load() != CONNECTED {
-				err = c.Error()
-				c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
-				return errors.WithContext(err, WRITE)
+	if c.writeBufferSize+protocol.MessageV0Size+message.ContentLength > 1<<19 {
+		binary.BigEndian.PutUint16(encodedMessage[protocol.VersionV0Offset:protocol.VersionV0Offset+protocol.VersionV0Size], protocol.Version0)
+		binary.BigEndian.PutUint32(encodedMessage[protocol.FromV0Offset:protocol.FromV0Offset+protocol.FromV0Size], message.From)
+		binary.BigEndian.PutUint32(encodedMessage[protocol.ToV0Offset:protocol.ToV0Offset+protocol.ToV0Size], message.To)
+		binary.BigEndian.PutUint32(encodedMessage[protocol.IdV0Offset:protocol.IdV0Offset+protocol.IdV0Size], message.Id)
+		binary.BigEndian.PutUint32(encodedMessage[protocol.OperationV0Offset:protocol.OperationV0Offset+protocol.OperationV0Size], message.Operation+c.offset)
+		binary.BigEndian.PutUint64(encodedMessage[protocol.ContentLengthV0Offset:protocol.ContentLengthV0Offset+protocol.ContentLengthV0Size], message.ContentLength)
+		if c.writeBufferSize > 0 {
+			if message.ContentLength > 0 {
+				n, err := c.conn.Write(append(c.writeBuffer[:c.writeBufferSize], append(encodedMessage[:], *content...)...))
+				if err != nil {
+					c.Unlock()
+					if c.state.Load() != CONNECTED {
+						err = c.Error()
+						c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+						return errors.WithContext(err, WRITE)
+					}
+					c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+					return c.closeWithError(err)
+				}
+				if n != int(c.writeBufferSize+protocol.MessageV0Size+message.ContentLength) {
+					c.Unlock()
+					if c.state.Load() != CONNECTED {
+						err = c.Error()
+						c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+						return errors.WithContext(err, WRITE)
+					}
+					c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+					return c.closeWithError(err)
+				}
+			} else {
+				n, err := c.conn.Write(append(c.writeBuffer[:c.writeBufferSize], encodedMessage[:]...))
+				if err != nil {
+					c.Unlock()
+					if c.state.Load() != CONNECTED {
+						err = c.Error()
+						c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+						return errors.WithContext(err, WRITE)
+					}
+					c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+					return c.closeWithError(err)
+				}
+				if n != int(c.writeBufferSize+protocol.MessageV0Size) {
+					c.Unlock()
+					if c.state.Load() != CONNECTED {
+						err = c.Error()
+						c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+						return errors.WithContext(err, WRITE)
+					}
+					c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+					return c.closeWithError(err)
+				}
 			}
-			c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
-			return c.closeWithError(err)
+			c.writeBufferSize = 0
+		} else {
+			if message.ContentLength > 0 {
+				n, err := c.conn.Write(append(encodedMessage[:], *content...))
+				if err != nil {
+					c.Unlock()
+					if c.state.Load() != CONNECTED {
+						err = c.Error()
+						c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+						return errors.WithContext(err, WRITE)
+					}
+					c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+					return c.closeWithError(err)
+				}
+				if n != int(protocol.MessageV0Size+message.ContentLength) {
+					c.Unlock()
+					if c.state.Load() != CONNECTED {
+						err = c.Error()
+						c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+						return errors.WithContext(err, WRITE)
+					}
+					c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+					return c.closeWithError(err)
+				}
+			} else {
+				n, err := c.conn.Write(encodedMessage[:])
+				if err != nil {
+					c.Unlock()
+					if c.state.Load() != CONNECTED {
+						err = c.Error()
+						c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+						return errors.WithContext(err, WRITE)
+					}
+					c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+					return c.closeWithError(err)
+				}
+				if n != protocol.MessageV0Size {
+					c.Unlock()
+					if c.state.Load() != CONNECTED {
+						err = c.Error()
+						c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+						return errors.WithContext(err, WRITE)
+					}
+					c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+					return c.closeWithError(err)
+				}
+			}
+		}
+	} else {
+		c.writeBuffer[c.writeBufferSize] = 0
+		c.writeBuffer[c.writeBufferSize+1] = 0
+		c.writeBuffer[c.writeBufferSize+2] = 0
+		c.writeBuffer[c.writeBufferSize+3] = 0
+		c.writeBuffer[c.writeBufferSize+4] = 0
+		c.writeBuffer[c.writeBufferSize+5] = 0
+		binary.BigEndian.PutUint16(c.writeBuffer[c.writeBufferSize+protocol.VersionV0Offset:c.writeBufferSize+protocol.VersionV0Offset+protocol.VersionV0Size], protocol.Version0)
+		binary.BigEndian.PutUint32(c.writeBuffer[c.writeBufferSize+protocol.FromV0Offset:c.writeBufferSize+protocol.FromV0Offset+protocol.FromV0Size], message.From)
+		binary.BigEndian.PutUint32(c.writeBuffer[c.writeBufferSize+protocol.ToV0Offset:c.writeBufferSize+protocol.ToV0Offset+protocol.ToV0Size], message.To)
+		binary.BigEndian.PutUint32(c.writeBuffer[c.writeBufferSize+protocol.IdV0Offset:c.writeBufferSize+protocol.IdV0Offset+protocol.IdV0Size], message.Id)
+		binary.BigEndian.PutUint32(c.writeBuffer[c.writeBufferSize+protocol.OperationV0Offset:c.writeBufferSize+protocol.OperationV0Offset+protocol.OperationV0Size], message.Operation+c.offset)
+		binary.BigEndian.PutUint64(c.writeBuffer[c.writeBufferSize+protocol.ContentLengthV0Offset:c.writeBufferSize+protocol.ContentLengthV0Offset+protocol.ContentLengthV0Size], message.ContentLength)
+		c.writeBufferSize += protocol.MessageV0Size
+		if message.ContentLength > 0 {
+			copy(c.writeBuffer[c.writeBufferSize:], *content)
+			c.writeBufferSize += message.ContentLength
+		}
+		if len(c.flusher) == 0 {
+			select {
+			case c.flusher <- struct{}{}:
+			default:
+			}
 		}
 	}
-
-	if len(c.flusher) == 0 {
-		select {
-		case c.flusher <- struct{}{}:
-		default:
-		}
-	}
-
 	c.Unlock()
-
 	return nil
 }
 
 // Flush allows for synchronous messaging by flushing the message buffer and instantly sending messages
 func (c *Conn) Flush() error {
 	c.Lock()
-	if c.writer.Buffered() > 0 {
-		err := c.writer.Flush()
+	if c.writeBufferSize > 0 {
+		n, err := c.conn.Write(c.writeBuffer[:c.writeBufferSize])
 		if err != nil {
 			c.Unlock()
 			_ = c.closeWithError(err)
-			return err
+			return c.Error()
 		}
+		if n != int(c.writeBufferSize) {
+			c.Unlock()
+			_ = c.closeWithError(ShortWrite)
+			return c.Error()
+		}
+		c.writeBufferSize = 0
 	}
 	c.Unlock()
 	return nil
@@ -197,9 +291,9 @@ func (c *Conn) WriteBufferSize() int {
 		c.Unlock()
 		return 0
 	}
-	i := c.writer.Buffered()
+	i := c.writeBufferSize
 	c.Unlock()
-	return i
+	return int(i)
 }
 
 // Read is a blocking function that will wait until a frisbee message is available and then return it (and its content).
@@ -274,11 +368,7 @@ func (c *Conn) close() error {
 	if c.state.CAS(CONNECTED, CLOSED) {
 		c.error.Store(ConnectionClosed)
 		c.killGoroutines()
-		c.Lock()
-		if c.writer.Buffered() > 0 {
-			_ = c.writer.Flush()
-		}
-		c.Unlock()
+		_ = c.Flush()
 		return nil
 	} else if c.state.CAS(PAUSED, CLOSED) {
 		c.error.Store(ConnectionClosed)
@@ -320,14 +410,21 @@ func (c *Conn) flushLoop() {
 			return
 		}
 		c.Lock()
-		if c.writer.Buffered() > 0 {
-			err := c.writer.Flush()
+		if c.writeBufferSize > 0 {
+			n, err := c.conn.Write(c.writeBuffer[:c.writeBufferSize])
 			if err != nil {
-				c.Unlock()
 				c.wg.Done()
+				c.Unlock()
 				_ = c.closeWithError(err)
 				return
 			}
+			if n != int(c.writeBufferSize) {
+				c.wg.Done()
+				c.Unlock()
+				_ = c.closeWithError(ShortWrite)
+				return
+			}
+			c.writeBufferSize = 0
 		}
 		c.Unlock()
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -216,9 +216,9 @@ func TestReadClose(t *testing.T) {
 	err = readerConn.conn.Close()
 	assert.NoError(t, err)
 
+	time.Sleep(time.Second * 1)
+
 	err = writerConn.Write(message, nil)
-	assert.NoError(t, err)
-	err = writerConn.Flush()
 	assert.Error(t, err)
 	assert.ErrorIs(t, writerConn.Error(), ConnectionPaused)
 

--- a/frisbee.go
+++ b/frisbee.go
@@ -53,6 +53,7 @@ var (
 	ConnectionNotInitialized = errors.New("connection not initialized")
 	InvalidBufferContents    = errors.New("invalid buffer contents")
 	InvalidBufferLength      = errors.New("invalid buffer length")
+	ShortWrite               = errors.New("short write to buffer")
 )
 
 // Action is an ENUM used to modify the state of the client or server from a router function


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue has been fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The write loop previously relied on a bufio.Writer, it's been modified to now use a simple byte array

Fixes JIRA-LOOP-91

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] New feature (non-breaking change which adds functionality) [title: 'feat:']

## Testing

Please make sure that existing test cases pass (with `go test ./... -race` and `go test -bench=. ./... -race`), 
and if required please add new test cases and list them below:

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:

```shell
BenchmarkThroughputPipe32-16                                  48          23419381 ns/op
BenchmarkThroughputPipe512-16                                 28          36146892 ns/op
BenchmarkThroughputNetwork32-16                               51          21112938 ns/op
BenchmarkThroughputNetwork512-16                              31          32490331 ns/op
BenchmarkThroughputNetwork1024-16                             22          46096754 ns/op
BenchmarkThroughputNetwork2048-16                             15          77386474 ns/op
BenchmarkThroughputNetwork4096-16                              7         158417140 ns/op
BenchmarkThroughputNetwork1mb-16                             278           4321259 ns/op
BenchmarkThroughput/test-16                                   36          34649100 ns/op
BenchmarkThroughputWithResponse/test-16                       31          34950986 ns/op
PASS
ok      github.com/loophole-labs/frisbee        18.245s
?       github.com/loophole-labs/frisbee/internal/errors        [no test files]
goos: darwin
goarch: amd64
pkg: github.com/loophole-labs/frisbee/internal/protocol
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkEncodeHandler-16               77164755                15.07 ns/op
BenchmarkDecodeHandler-16               100000000               11.66 ns/op
BenchmarkEncodeDecodeHandler-16         36798249                29.55 ns/op
BenchmarkEncode-16                      73435366                15.46 ns/op
BenchmarkDecode-16                      149592734                8.208 ns/op
BenchmarkEncodeDecode-16                45068934                26.98 ns/op
PASS
ok      github.com/loophole-labs/frisbee/internal/protocol      8.029s
PASS
ok      github.com/loophole-labs/frisbee/internal/ringbuffer    0.095s
```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `go fmt ./...` has been run
- [x] `golangci-lint run --skip-dirs-use-default` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
