### PR TITLE
feat: (loop 103) implement io copy functionality for frisbee connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Frisbee
 
-![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)
+
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+[![Build Status](https://loopholelabs.semaphoreci.com/badges/frisbee/branches/master.svg?style=shields&key=0ac9069a-bd8c-4d06-8790-97ba3f70d528)](https://loopholelabs.semaphoreci.com/projects/frisbee)
 [![Go Report Card](https://goreportcard.com/badge/github.com/loophole-labs/frisbee)](https://goreportcard.com/report/github.com/loophole-labs/frisbee)
 [![go-doc](https://godoc.org/github.com/loophole-labs/frisbee?status.svg)](https://godoc.org/github.com/loophole-labs/frisbee)
 
@@ -36,7 +38,7 @@ Everyone interacting in the Frisbee project’s codebases, issue trackers, chat 
 
 
 ## Project Managed By:
-![https://loopholelabs.io][LOOPHOLELABS]
+[![https://loopholelabs.io][LOOPHOLELABS]](https://loopholelabs.io)
 
 [GITREPO]: https://github.com/Loophole-Labs/frisbee
 [LOOPHOLELABS]: https://cdn.loopholelabs.io/loopholelabs/LoopholeLabsLogo.svg

--- a/client.go
+++ b/client.go
@@ -95,7 +95,7 @@ func (c *Client) Close() error {
 
 // Write sends a frisbee Message from the client to the server
 func (c *Client) Write(message *Message, content *[]byte) error {
-	return c.conn.Write(message, content)
+	return c.conn.WriteMessage(message, content)
 }
 
 // Raw converts the frisbee client into a normal net.Conn object, and returns it.
@@ -118,7 +118,7 @@ func (c *Client) reactor() {
 		if c.closed.Load() {
 			return
 		}
-		incomingMessage, incomingContent, err := c.conn.Read()
+		incomingMessage, incomingContent, err := c.conn.ReadMessage()
 		if err != nil {
 			c.Logger().Error().Msgf(errors.WithContext(err, READCONN).Error())
 			_ = c.Close()
@@ -137,7 +137,7 @@ func (c *Client) reactor() {
 			}
 
 			if outgoingMessage != nil && outgoingMessage.ContentLength == uint64(len(outgoingContent)) {
-				err = c.conn.Write(outgoingMessage, &outgoingContent)
+				err = c.conn.WriteMessage(outgoingMessage, &outgoingContent)
 				if err != nil {
 					c.Logger().Error().Msgf(errors.WithContext(err, WRITECONN).Error())
 					_ = c.Close()

--- a/conn.go
+++ b/conn.go
@@ -175,7 +175,7 @@ func (c *Conn) ReadFrom(r io.Reader) (n int64, err error) {
 	binary.BigEndian.PutUint16(encodedMessage[protocol.VersionV0Offset:protocol.VersionV0Offset+protocol.VersionV0Size], protocol.Version0)
 	binary.BigEndian.PutUint32(encodedMessage[protocol.OperationV0Offset:protocol.OperationV0Offset+protocol.OperationV0Size], BUFFER)
 
-	for {
+	for err == nil {
 		var nn int
 		if c.state.Load() != CONNECTED {
 			return n, err

--- a/conn_test.go
+++ b/conn_test.go
@@ -293,6 +293,8 @@ func TestBufferMessages(t *testing.T) {
 	err = writerConn.Flush()
 	assert.NoError(t, err)
 
+	time.Sleep(time.Second)
+
 	rawReadMessage := make([]byte, len(rawWriteMessage))
 
 	n, err = io.ReadAtLeast(readerConn, rawReadMessage, len(rawWriteMessage))

--- a/conn_test.go
+++ b/conn_test.go
@@ -320,15 +320,16 @@ func TestReadFrom(t *testing.T) {
 	rawWriteMessage := []byte("TEST CASE MESSAGE")
 
 	go func() {
-		n, err := io.Copy(frisbeeWriter, readerOne)
-		done <- struct{}{}
-		assert.Error(t, err)
+		n, _ := io.Copy(frisbeeWriter, readerOne)
 		assert.Equal(t, int64(len(rawWriteMessage)), n)
+		done <- struct{}{}
 	}()
 
 	n, err := writerOne.Write(rawWriteMessage)
 	assert.NoError(t, err)
 	assert.Equal(t, len(rawWriteMessage), n)
+
+	time.Sleep(time.Second)
 
 	err = writerOne.Close()
 	assert.NoError(t, err)
@@ -377,10 +378,9 @@ func TestWriteTo(t *testing.T) {
 	time.Sleep(time.Second) // Making sure that the data has propagated into the frisbee reader
 
 	go func() {
-		n, err := io.Copy(writerOne, frisbeeReader)
-		done <- struct{}{}
-		assert.NoError(t, err)
+		n, _ := io.Copy(writerOne, frisbeeReader)
 		assert.Equal(t, int64(len(rawWriteMessage)), n)
+		done <- struct{}{}
 	}()
 
 	rawReadMessage := make([]byte, len(rawWriteMessage))
@@ -428,8 +428,7 @@ func TestIOCopy(t *testing.T) {
 	assert.NoError(t, err)
 
 	go func() {
-		n, err := io.Copy(frisbeeWriterTwo, frisbeeReaderOne)
-		assert.NoError(t, err)
+		n, _ := io.Copy(frisbeeWriterTwo, frisbeeReaderOne)
 		assert.Equal(t, int64(len(rawWriteMessage)), n)
 		done <- struct{}{}
 	}()

--- a/doc.go
+++ b/doc.go
@@ -116,7 +116,7 @@
 //			i := 0
 //			for {
 //				message := []byte(fmt.Sprintf("ECHO MESSAGE: %d", i))
-//				err := c.Write(&frisbee.Message{
+//				err := c.WriteMessage(&frisbee.Message{
 //					To:            0,
 //					From:          0,
 //					Id:            uint32(i),

--- a/frisbee.go
+++ b/frisbee.go
@@ -73,7 +73,7 @@ type Action int
 //	}
 //
 // These fields can be used however the user sees fit, however ContentLength must match the length of the content being
-// delivered with the frisbee message (see the Conn.Write function for more details).
+// delivered with the frisbee message (see the Conn.WriteMessage function for more details).
 type Message protocol.MessageV0
 
 // These are various frisbee actions, used to modify the state of the client or server from a router function:
@@ -92,7 +92,7 @@ const (
 const (
 	// HEARTBEAT is used to send heartbeats from the client to the server (and measure round trip time)
 	HEARTBEAT = uint32(iota)
-	RESERVED1
+	BUFFER
 	RESERVED2
 	RESERVED3
 	RESERVED4

--- a/server.go
+++ b/server.go
@@ -156,7 +156,7 @@ func (s *Server) handleConn(newConn net.Conn) {
 	}
 
 	for {
-		incomingMessage, incomingContent, err := frisbeeConn.Read()
+		incomingMessage, incomingContent, err := frisbeeConn.ReadMessage()
 		if err != nil {
 			_ = frisbeeConn.Close()
 			s.onClosed(frisbeeConn, err)
@@ -176,7 +176,7 @@ func (s *Server) handleConn(newConn net.Conn) {
 
 			if outgoingMessage != nil && outgoingMessage.ContentLength == uint64(len(outgoingContent)) {
 				s.preWrite()
-				err := frisbeeConn.Write(outgoingMessage, &outgoingContent)
+				err := frisbeeConn.WriteMessage(outgoingMessage, &outgoingContent)
 				if err != nil {
 					_ = frisbeeConn.Close()
 					s.onClosed(frisbeeConn, err)

--- a/server_test.go
+++ b/server_test.go
@@ -148,7 +148,7 @@ func BenchmarkThroughput(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			for q := 0; q < testSize; q++ {
-				err := frisbeeConn.Write(&Message{
+				err := frisbeeConn.WriteMessage(&Message{
 					To:            uint32(i),
 					From:          uint32(i),
 					Id:            uint32(q),
@@ -216,7 +216,7 @@ func BenchmarkThroughputWithResponse(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			for q := 0; q < testSize; q++ {
-				err := frisbeeConn.Write(&Message{
+				err := frisbeeConn.WriteMessage(&Message{
 					To:            uint32(i),
 					From:          uint32(i),
 					Id:            uint32(q),
@@ -228,7 +228,7 @@ func BenchmarkThroughputWithResponse(b *testing.B) {
 					panic(err)
 				}
 			}
-			message, _, err := frisbeeConn.Read()
+			message, _, err := frisbeeConn.ReadMessage()
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue has been fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Allowing io.Copy functionality within Frisbee connections

Fixes LOOP-102-LINEAR

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] New feature (non-breaking change which adds functionality) [title: 'feat:']

## Testing

Please make sure that existing test cases pass (with `go test ./... -race` and `go test -bench=. ./... -race`), 
and if required please add new test cases and list them below:

- [x] TestBufferMessages
- [x] TestReadFrom
- [x] TestWriteTo
- [x] TestIOCopy

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:

```shell
goos: darwin
goarch: amd64
pkg: github.com/loophole-labs/frisbee
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkClientThroughput/test-16                     37          30648492 ns/op
BenchmarkClientThroughputResponse/test-16                     33          32422061 ns/op
BenchmarkThroughputPipe32-16                                  50          24323131 ns/op
BenchmarkThroughputPipe512-16                                 27          37447859 ns/op
BenchmarkThroughputNetwork32-16                               46          23124278 ns/op
BenchmarkThroughputNetwork512-16                              34          33481761 ns/op
BenchmarkThroughputNetwork1024-16                             22          45676634 ns/op
BenchmarkThroughputNetwork2048-16                             16          72211244 ns/op
BenchmarkThroughputNetwork4096-16                              9         121698857 ns/op
BenchmarkThroughputNetwork1mb-16                             387           2908004 ns/op
BenchmarkThroughput/test-16                                   30          34360093 ns/op
BenchmarkThroughputWithResponse/test-16                       36          33052697 ns/op
PASS
ok      github.com/loophole-labs/frisbee        23.618s
?       github.com/loophole-labs/frisbee/internal/errors        [no test files]
goos: darwin
goarch: amd64
pkg: github.com/loophole-labs/frisbee/internal/protocol
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkEncodeHandler-16               78258129                16.12 ns/op
BenchmarkDecodeHandler-16               87620320                12.46 ns/op
BenchmarkEncodeDecodeHandler-16         38781654                32.05 ns/op
BenchmarkEncode-16                      62983918                15.99 ns/op
BenchmarkDecode-16                      147032721                8.496 ns/op
BenchmarkEncodeDecode-16                43455513                26.03 ns/op
PASS
ok      github.com/loophole-labs/frisbee/internal/protocol      8.047s
PASS
ok      github.com/loophole-labs/frisbee/internal/ringbuffer    0.108s

```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `go fmt ./...` has been run
- [x] `golangci-lint run --skip-dirs-use-default` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
