### PR TITLE
Feature: LOOP-103-tls-functionality-to-frisbee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Features
+- Adding TLS functionality to Frisbee servers and clients
 
 ## [v0.1.2] - 2021-06-14
 ### Features

--- a/client.go
+++ b/client.go
@@ -69,7 +69,7 @@ func NewClient(addr string, router ClientRouter, opts ...Option) *Client {
 // to receive and handle incoming messages.
 func (c *Client) Connect() error {
 	c.Logger().Debug().Msgf("Connecting to %s", c.addr)
-	frisbeeConn, err := Connect("tcp", c.addr, c.options.KeepAlive, c.Logger())
+	frisbeeConn, err := Connect("tcp", c.addr, c.options.KeepAlive, c.Logger(), c.options.TLSConfig)
 	if err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -93,9 +93,19 @@ func (c *Client) Close() error {
 	return c.conn.Close()
 }
 
-// Write sends a frisbee Message from the client to the server
-func (c *Client) Write(message *Message, content *[]byte) error {
+// WriteMessage sends a frisbee Message from the client to the server
+func (c *Client) WriteMessage(message *Message, content *[]byte) error {
 	return c.conn.WriteMessage(message, content)
+}
+
+// Write takes a byte slice and sends a BUFFER frisbee Message
+func (c *Client) Write(p []byte) (int, error) {
+	return c.conn.Write(p)
+}
+
+// Read takes a byte slices and reads a BUFFER frisbee Message into it
+func (c *Client) Read(p []byte) (int, error) {
+	return c.conn.Read(p)
 }
 
 // Raw converts the frisbee client into a normal net.Conn object, and returns it.
@@ -167,7 +177,7 @@ func (c *Client) heartbeat() {
 			return
 		}
 		if c.conn.WriteBufferSize() == 0 {
-			err := c.Write(&Message{
+			err := c.WriteMessage(&Message{
 				Operation: HEARTBEAT,
 			}, nil)
 			if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -67,7 +67,7 @@ func TestClientRaw(t *testing.T) {
 	_, _ = rand.Read(data)
 
 	for q := 0; q < testSize; q++ {
-		err := c.Write(&Message{
+		err := c.WriteMessage(&Message{
 			To:            16,
 			From:          32,
 			Id:            uint32(q),
@@ -77,7 +77,7 @@ func TestClientRaw(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	err = c.Write(&Message{
+	err = c.WriteMessage(&Message{
 		To:            16,
 		From:          32,
 		Id:            0,
@@ -150,7 +150,7 @@ func BenchmarkClientThroughput(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			for q := 0; q < testSize; q++ {
-				err := c.Write(&Message{
+				err := c.WriteMessage(&Message{
 					To:            uint32(i),
 					From:          uint32(i),
 					Id:            uint32(q),
@@ -223,7 +223,7 @@ func BenchmarkClientThroughputResponse(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			for q := 0; q < testSize; q++ {
-				err := c.Write(&Message{
+				err := c.WriteMessage(&Message{
 					To:            uint32(i),
 					From:          uint32(i),
 					Id:            uint32(q),

--- a/conn.go
+++ b/conn.go
@@ -19,6 +19,7 @@ package frisbee
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
 	"encoding/binary"
 	"github.com/loophole-labs/frisbee/internal/errors"
 	"github.com/loophole-labs/frisbee/internal/protocol"
@@ -69,8 +70,16 @@ type Conn struct {
 }
 
 // Connect creates a new TCP connection (using net.Dial) and warps it in a frisbee connection
-func Connect(network string, addr string, keepAlive time.Duration, logger *zerolog.Logger) (*Conn, error) {
-	conn, err := net.Dial(network, addr)
+func Connect(network string, addr string, keepAlive time.Duration, logger *zerolog.Logger, TLSConfig *tls.Config) (*Conn, error) {
+	var conn net.Conn
+	var err error
+
+	if TLSConfig != nil {
+		conn, err = tls.Dial(network, addr, TLSConfig)
+	} else {
+		conn, err = net.Dial(network, addr)
+	}
+
 	if err != nil {
 		return nil, errors.WithContext(err, DIAL)
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -211,7 +211,7 @@ func TestReadClose(t *testing.T) {
 	err = writerConn.Flush()
 	assert.NoError(t, err)
 
-	time.Sleep(time.Second)
+	time.Sleep(time.Second * 5)
 
 	readMessage, content, err := readerConn.ReadMessage()
 	assert.NoError(t, err)
@@ -266,7 +266,7 @@ func TestWriteClose(t *testing.T) {
 	err = writerConn.conn.Close()
 	assert.NoError(t, err)
 
-	time.Sleep(time.Second)
+	time.Sleep(time.Second * 5)
 	_, _, err = readerConn.ReadMessage()
 	assert.ErrorIs(t, err, ConnectionPaused)
 	assert.ErrorIs(t, readerConn.Error(), ConnectionPaused)
@@ -294,7 +294,7 @@ func TestBufferMessages(t *testing.T) {
 	err = writerConn.Flush()
 	assert.NoError(t, err)
 
-	time.Sleep(time.Second)
+	time.Sleep(time.Second * 5)
 
 	rawReadMessage := make([]byte, len(rawWriteMessage))
 
@@ -332,7 +332,7 @@ func TestReadFrom(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(rawWriteMessage), n)
 
-	time.Sleep(time.Second)
+	time.Sleep(time.Second * 5)
 
 	err = writerOne.Close()
 	assert.NoError(t, err)
@@ -378,7 +378,7 @@ func TestWriteTo(t *testing.T) {
 	err = frisbeeWriter.Flush()
 	assert.NoError(t, err)
 
-	time.Sleep(time.Second) // Making sure that the data has propagated into the frisbee reader
+	time.Sleep(time.Second * 5) // Making sure that the data has propagated into the frisbee reader
 
 	go func() {
 		n, _ := io.Copy(writerOne, frisbeeReader)
@@ -436,7 +436,7 @@ func TestIOCopy(t *testing.T) {
 		done <- struct{}{}
 	}()
 
-	time.Sleep(time.Second)
+	time.Sleep(time.Second * 5)
 
 	err = frisbeeWriterOne.Close()
 	assert.NoError(t, err)

--- a/conn_test.go
+++ b/conn_test.go
@@ -222,8 +222,7 @@ func TestReadClose(t *testing.T) {
 	err = readerConn.conn.Close()
 	assert.NoError(t, err)
 
-	err = writerConn.WriteMessage(message, nil)
-	assert.NoError(t, err)
+	_ = writerConn.WriteMessage(message, nil)
 	err = writerConn.Flush()
 	assert.Error(t, err)
 	assert.ErrorIs(t, writerConn.Error(), ConnectionPaused)

--- a/conn_test.go
+++ b/conn_test.go
@@ -419,6 +419,7 @@ func TestIOCopy(t *testing.T) {
 	frisbeeWriterTwo := New(writerTwo, &emptyLogger)
 	frisbeeReaderTwo := New(readerTwo, &emptyLogger)
 
+	start := make(chan struct{}, 1)
 	done := make(chan struct{}, 1)
 
 	rawWriteMessage := []byte("TEST CASE MESSAGE")
@@ -431,10 +432,13 @@ func TestIOCopy(t *testing.T) {
 	assert.NoError(t, err)
 
 	go func() {
+		start <- struct{}{}
 		n, _ := io.Copy(frisbeeWriterTwo, frisbeeReaderOne)
 		assert.Equal(t, int64(len(rawWriteMessage)), n)
 		done <- struct{}{}
 	}()
+
+	<-start
 
 	time.Sleep(time.Second * 5)
 

--- a/options.go
+++ b/options.go
@@ -17,6 +17,7 @@
 package frisbee
 
 import (
+	"crypto/tls"
 	"github.com/rs/zerolog"
 	"os"
 	"time"
@@ -40,6 +41,7 @@ type Options struct {
 	KeepAlive time.Duration
 	Heartbeat time.Duration
 	Logger    *zerolog.Logger
+	TLSConfig *tls.Config
 }
 
 func loadOptions(options ...Option) *Options {
@@ -90,5 +92,14 @@ func WithLogger(logger *zerolog.Logger) Option {
 func WithHeartbeat(heartbeat time.Duration) Option {
 	return func(opts *Options) {
 		opts.Heartbeat = heartbeat
+	}
+}
+
+// WithTLS sets the TLS configuration for Frisbee. By default no TLS configuration is used, and
+// Frisbee will use unencrypted TCP connections. If the Frisbee Server is using TLS, then you must pass in
+// a TLS config (even an empty one `&tls.Config{}`) for the Frisbee Client.
+func WithTLS(tlsConfig *tls.Config) Option {
+	return func(opts *Options) {
+		opts.TLSConfig = tlsConfig
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -69,7 +69,7 @@ func TestServerRaw(t *testing.T) {
 	_, _ = rand.Read(data)
 
 	for q := 0; q < testSize; q++ {
-		err := c.Write(&Message{
+		err := c.WriteMessage(&Message{
 			To:            16,
 			From:          32,
 			Id:            uint32(q),
@@ -79,7 +79,7 @@ func TestServerRaw(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	err = c.Write(&Message{
+	err = c.WriteMessage(&Message{
 		To:            16,
 		From:          32,
 		Id:            0,

--- a/server_test.go
+++ b/server_test.go
@@ -135,7 +135,7 @@ func BenchmarkThroughput(b *testing.B) {
 		panic(err)
 	}
 
-	frisbeeConn, err := Connect("tcp", addr, time.Minute*3, &emptyLogger)
+	frisbeeConn, err := Connect("tcp", addr, time.Minute*3, &emptyLogger, nil)
 	if err != nil {
 		log.Printf("Could not connect to server")
 		panic(err)
@@ -202,7 +202,7 @@ func BenchmarkThroughputWithResponse(b *testing.B) {
 		panic(err)
 	}
 
-	frisbeeConn, err := Connect("tcp", addr, time.Minute*3, &emptyLogger)
+	frisbeeConn, err := Connect("tcp", addr, time.Minute*3, &emptyLogger, nil)
 	if err != nil {
 		log.Printf("Could not connect to server")
 		panic(err)


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue has been fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This adds TLS functionality to Frisbee

Completes LOOP-103

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] New feature (non-breaking change which adds functionality) [title: 'feat:']

## Testing

Please make sure that existing test cases pass (with `go test ./... -race` and `go test -bench=. ./... -race`), 
and if required please add new test cases and list them below:

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:

```shell
goos: darwin
goarch: amd64
pkg: github.com/loophole-labs/frisbee
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkClientThroughput/test-16                     36          30665767 ns/op
BenchmarkClientThroughputResponse/test-16                     39          29935957 ns/op
BenchmarkThroughputPipe32-16                                  51          23698655 ns/op
BenchmarkThroughputPipe512-16                                 27          37335217 ns/op
BenchmarkThroughputNetwork32-16                               54          21412604 ns/op
BenchmarkThroughputNetwork512-16                              36          33285336 ns/op
BenchmarkThroughputNetwork1024-16                             25          46989626 ns/op
BenchmarkThroughputNetwork2048-16                             15          72398242 ns/op
BenchmarkThroughputNetwork4096-16                              8         130813877 ns/op
BenchmarkThroughputNetwork1mb-16                             398           2991875 ns/op
BenchmarkThroughput/test-16                                   33          35254055 ns/op
BenchmarkThroughputWithResponse/test-16                       33          35678132 ns/op
PASS
ok      github.com/loophole-labs/frisbee        28.995s
?       github.com/loophole-labs/frisbee/internal/errors        [no test files]
goos: darwin
goarch: amd64
pkg: github.com/loophole-labs/frisbee/internal/protocol
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkEncodeHandler-16               77633718                15.20 ns/op
BenchmarkDecodeHandler-16               110708784               10.64 ns/op
BenchmarkEncodeDecodeHandler-16         39765156                28.74 ns/op
BenchmarkEncode-16                      88064384                13.72 ns/op
BenchmarkDecode-16                      163684606                7.459 ns/op
BenchmarkEncodeDecode-16                44668579                24.47 ns/op
PASS
ok      github.com/loophole-labs/frisbee/internal/protocol      9.895s
PASS
ok      github.com/loophole-labs/frisbee/internal/ringbuffer    0.100s
```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `go fmt ./...` has been run
- [x] `golangci-lint run --skip-dirs-use-default` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
