### PR TITLE
Feature: LOOP-106-Stream-Multiplexing

### DIFF
--- a/client.go
+++ b/client.go
@@ -118,16 +118,6 @@ func (c *Client) WriteMessage(message *Message, content *[]byte) error {
 	return c.conn.WriteMessage(message, content)
 }
 
-// Write takes a byte slice and sends a BUFFER frisbee Message
-func (c *Client) Write(p []byte) (int, error) {
-	return c.conn.Write(p)
-}
-
-// Read takes a byte slices and reads a BUFFER frisbee Message into it
-func (c *Client) Read(p []byte) (int, error) {
-	return c.conn.Read(p)
-}
-
 // Raw converts the frisbee client into a normal net.Conn object, and returns it.
 // This is especially useful in proxying and streaming scenarios.
 func (c *Client) Raw() (net.Conn, error) {

--- a/client.go
+++ b/client.go
@@ -87,6 +87,16 @@ func (c *Client) Connect() error {
 	return nil
 }
 
+// StreamConnCh returns a channel that can be listened on to retrieve stream connections as they're created
+func (c *Client) StreamConnCh() <-chan *StreamConn {
+	return c.conn.StreamConnCh
+}
+
+// NewStreamConn creates a new StreamConn from the underlying frisbee.Conn
+func (c *Client) NewStreamConn(id uint32) *StreamConn {
+	return c.conn.NewStreamConn(id)
+}
+
 // Closed checks whether this client has been closed
 func (c *Client) Closed() bool {
 	return c.closed.Load()

--- a/conn.go
+++ b/conn.go
@@ -832,9 +832,9 @@ func (s *StreamConn) Closed() bool {
 	return s.closed.Load()
 }
 
-func (s *StreamConn) Close() {
+func (s *StreamConn) Close() error {
 	s.closed.Store(true)
-	_ = s.WriteMessage(&Message{
+	return s.WriteMessage(&Message{
 		Id:            s.id,
 		Operation:     STREAMCLOSE,
 		ContentLength: 0,

--- a/conn.go
+++ b/conn.go
@@ -905,7 +905,7 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 
 		nn, err = r.Read(buf)
 		if nn == 0 {
-			continue
+			break
 		}
 
 		if err != nil {

--- a/conn.go
+++ b/conn.go
@@ -798,12 +798,18 @@ type StreamConn struct {
 }
 
 func (c *Conn) NewStreamConn(id uint32) *StreamConn {
-	return &StreamConn{
+	streamConn := &StreamConn{
 		Conn:           c,
 		id:             id,
 		incomingBuffer: newIncomingBuffer(),
 		closed:         atomic.NewBool(false),
 	}
+
+	c.streamConnMutex.Lock()
+	c.streamConns[id] = streamConn
+	c.streamConnMutex.Unlock()
+
+	return streamConn
 }
 
 func (s *StreamConn) ID() uint32 {

--- a/conn.go
+++ b/conn.go
@@ -812,6 +812,18 @@ func (c *Conn) NewStreamConn(id uint32) *StreamConn {
 	return streamConn
 }
 
+func (s *StreamConn) SetDeadline(t time.Time) error {
+	return s.conn.SetDeadline(t)
+}
+
+func (s *StreamConn) SetReadDeadline(t time.Time) error {
+	return s.conn.SetReadDeadline(t)
+}
+
+func (s *StreamConn) SetWriteDeadline(t time.Time) error {
+	return s.conn.SetWriteDeadline(t)
+}
+
 func (s *StreamConn) ID() uint32 {
 	return s.id
 }

--- a/conn.go
+++ b/conn.go
@@ -825,6 +825,7 @@ func (s *StreamConn) Close() {
 
 // Write takes a byte slice and sends a STREAM message
 func (s *StreamConn) Write(p []byte) (int, error) {
+	s.Logger().Debug().Msgf("StreamConn Write called with size %d", len(p))
 	var encodedMessage [protocol.MessageV0Size]byte
 
 	binary.BigEndian.PutUint16(encodedMessage[protocol.VersionV0Offset:protocol.VersionV0Offset+protocol.VersionV0Size], protocol.Version0)
@@ -875,7 +876,7 @@ func (s *StreamConn) Write(p []byte) (int, error) {
 	}
 
 	s.Unlock()
-
+	s.Logger().Debug().Msgf("StreamConn Write done")
 	return len(p), nil
 }
 
@@ -889,6 +890,8 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 	binary.BigEndian.PutUint16(encodedMessage[protocol.VersionV0Offset:protocol.VersionV0Offset+protocol.VersionV0Size], protocol.Version0)
 	binary.BigEndian.PutUint32(encodedMessage[protocol.IdV0Offset:protocol.IdV0Offset+protocol.IdV0Size], s.id)
 	binary.BigEndian.PutUint32(encodedMessage[protocol.OperationV0Offset:protocol.OperationV0Offset+protocol.OperationV0Size], STREAM)
+
+	s.Logger().Debug().Msgf("StreamConn ReadFrom called")
 
 	for err == nil {
 		var nn int
@@ -952,6 +955,8 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 	if errors.Is(err, io.EOF) {
 		err = nil
 	}
+
+	s.Logger().Debug().Msgf("StreamConn ReadFrom done")
 
 	return
 }

--- a/conn.go
+++ b/conn.go
@@ -895,6 +895,8 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 	binary.BigEndian.PutUint32(encodedMessage[protocol.IdV0Offset:protocol.IdV0Offset+protocol.IdV0Size], s.id)
 	binary.BigEndian.PutUint32(encodedMessage[protocol.OperationV0Offset:protocol.OperationV0Offset+protocol.OperationV0Size], STREAM)
 
+	newReader := bufio.NewReader(r)
+
 	for {
 		var nn int
 		if s.state.Load() != CONNECTED {
@@ -904,7 +906,7 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 		if s.Closed() {
 			return n, ConnectionClosed
 		}
-		nn, err = r.Read(buf)
+		nn, err = newReader.Read(buf)
 		if nn == 0 || err != nil {
 			break
 		}

--- a/conn.go
+++ b/conn.go
@@ -804,6 +804,10 @@ func (c *Conn) NewStreamConn(id uint32) *StreamConn {
 	}
 }
 
+func (s *StreamConn) ID() uint32 {
+	return s.id
+}
+
 func (s *StreamConn) Closed() bool {
 	return s.closed.Load()
 }

--- a/conn.go
+++ b/conn.go
@@ -893,7 +893,7 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 
 	s.Logger().Debug().Msgf("StreamConn ReadFrom called")
 
-	for err == nil {
+	for {
 		var nn int
 		if s.state.Load() != CONNECTED {
 			return n, err
@@ -902,15 +902,13 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 		if s.Closed() {
 			return n, ConnectionClosed
 		}
-
+		s.Logger().Debug().Msgf("StreamConn ReadFrom READING")
 		nn, err = r.Read(buf)
-		if nn == 0 {
+		if nn == 0 || err != nil {
 			break
 		}
 
-		if err != nil {
-			break
-		}
+		s.Logger().Debug().Msgf("ReadFrom read %d bytes: %+v", nn, buf)
 
 		n += int64(nn)
 
@@ -948,6 +946,7 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 			default:
 			}
 		}
+		s.Logger().Debug().Msgf("ReadFrom finished read, looping: %d", n)
 
 		s.Unlock()
 	}

--- a/conn.go
+++ b/conn.go
@@ -895,8 +895,6 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 	binary.BigEndian.PutUint32(encodedMessage[protocol.IdV0Offset:protocol.IdV0Offset+protocol.IdV0Size], s.id)
 	binary.BigEndian.PutUint32(encodedMessage[protocol.OperationV0Offset:protocol.OperationV0Offset+protocol.OperationV0Size], STREAM)
 
-	newReader := bufio.NewReader(r)
-
 	for {
 		var nn int
 		if s.state.Load() != CONNECTED {
@@ -906,7 +904,7 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 		if s.Closed() {
 			return n, ConnectionClosed
 		}
-		nn, err = newReader.Read(buf)
+		nn, err = r.Read(buf)
 		if nn == 0 || err != nil {
 			break
 		}

--- a/conn.go
+++ b/conn.go
@@ -908,7 +908,7 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 			break
 		}
 
-		s.Logger().Debug().Msgf("ReadFrom read %d bytes: %+v", nn, buf)
+		s.Logger().Debug().Msgf("ReadFrom read %d bytes: %+v", nn, buf[:nn])
 
 		n += int64(nn)
 

--- a/conn.go
+++ b/conn.go
@@ -129,6 +129,18 @@ func New(c net.Conn, logger *zerolog.Logger) (conn *Conn) {
 	return
 }
 
+func (c *Conn) SetDeadline(t time.Time) error {
+	return c.conn.SetDeadline(t)
+}
+
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return c.conn.SetReadDeadline(t)
+}
+
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	return c.conn.SetWriteDeadline(t)
+}
+
 // LocalAddr returns the local address of the underlying net.Conn
 func (c *Conn) LocalAddr() net.Addr {
 	return c.conn.LocalAddr()
@@ -810,18 +822,6 @@ func (c *Conn) NewStreamConn(id uint32) *StreamConn {
 	c.streamConnMutex.Unlock()
 
 	return streamConn
-}
-
-func (s *StreamConn) SetDeadline(t time.Time) error {
-	return s.conn.SetDeadline(t)
-}
-
-func (s *StreamConn) SetReadDeadline(t time.Time) error {
-	return s.conn.SetReadDeadline(t)
-}
-
-func (s *StreamConn) SetWriteDeadline(t time.Time) error {
-	return s.conn.SetWriteDeadline(t)
 }
 
 func (s *StreamConn) ID() uint32 {

--- a/conn.go
+++ b/conn.go
@@ -908,7 +908,7 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 			break
 		}
 
-		s.Logger().Debug().Msgf("ReadFrom read %d bytes: %+v", nn, buf[:nn])
+		s.Logger().Debug().Msgf("ReadFrom ID %d, read %d bytes: %s", s.id, nn, string(buf[:nn]))
 
 		n += int64(nn)
 
@@ -946,7 +946,7 @@ func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
 			default:
 			}
 		}
-		s.Logger().Debug().Msgf("ReadFrom finished read, looping: %d", n)
+		s.Logger().Debug().Msgf("ReadFrom id %d finished read, looping: %d", s.id, n)
 
 		s.Unlock()
 	}

--- a/conn.go
+++ b/conn.go
@@ -189,77 +189,78 @@ func (c *Conn) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// ReadFrom is a function that will send buffer messages from an io.Reader until EOF or an error occurs
-// In the event that the connection is closed, ReadFrom will return an error.
-func (c *Conn) ReadFrom(r io.Reader) (n int64, err error) {
-	buf := make([]byte, DefaultBufferSize)
-
-	var encodedMessage [protocol.MessageV0Size]byte
-
-	binary.BigEndian.PutUint16(encodedMessage[protocol.VersionV0Offset:protocol.VersionV0Offset+protocol.VersionV0Size], protocol.Version0)
-	binary.BigEndian.PutUint32(encodedMessage[protocol.OperationV0Offset:protocol.OperationV0Offset+protocol.OperationV0Size], BUFFER)
-
-	for err == nil {
-		var nn int
-		if c.state.Load() != CONNECTED {
-			return n, err
-		}
-
-		nn, err = r.Read(buf)
-		if nn == 0 {
-			continue
-		}
-
-		if err != nil {
-			break
-		}
-
-		n += int64(nn)
-
-		binary.BigEndian.PutUint64(encodedMessage[protocol.ContentLengthV0Offset:protocol.ContentLengthV0Offset+protocol.ContentLengthV0Size], uint64(nn))
-
-		c.Lock()
-
-		_, err := c.writer.Write(encodedMessage[:])
-		if err != nil {
-			c.Unlock()
-			if c.state.Load() != CONNECTED {
-				err = c.Error()
-				c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
-				return n, errors.WithContext(err, WRITE)
-			}
-			c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
-			return n, c.closeWithError(err)
-		}
-
-		_, err = c.writer.Write(buf[:nn])
-		if err != nil {
-			c.Unlock()
-			if c.state.Load() != CONNECTED {
-				err = c.Error()
-				c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
-				return n, errors.WithContext(err, WRITE)
-			}
-			c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
-			return n, c.closeWithError(err)
-		}
-
-		if len(c.flusher) == 0 {
-			select {
-			case c.flusher <- struct{}{}:
-			default:
-			}
-		}
-
-		c.Unlock()
-	}
-
-	if errors.Is(err, io.EOF) {
-		err = nil
-	}
-
-	return
-}
+//
+//// ReadFrom is a function that will send buffer messages from an io.Reader until EOF or an error occurs
+//// In the event that the connection is closed, ReadFrom will return an error.
+//func (c *Conn) ReadFrom(r io.Reader) (n int64, err error) {
+//	buf := make([]byte, DefaultBufferSize)
+//
+//	var encodedMessage [protocol.MessageV0Size]byte
+//
+//	binary.BigEndian.PutUint16(encodedMessage[protocol.VersionV0Offset:protocol.VersionV0Offset+protocol.VersionV0Size], protocol.Version0)
+//	binary.BigEndian.PutUint32(encodedMessage[protocol.OperationV0Offset:protocol.OperationV0Offset+protocol.OperationV0Size], BUFFER)
+//
+//	for err == nil {
+//		var nn int
+//		if c.state.Load() != CONNECTED {
+//			return n, err
+//		}
+//
+//		nn, err = r.Read(buf)
+//		if nn == 0 {
+//			continue
+//		}
+//
+//		if err != nil {
+//			break
+//		}
+//
+//		n += int64(nn)
+//
+//		binary.BigEndian.PutUint64(encodedMessage[protocol.ContentLengthV0Offset:protocol.ContentLengthV0Offset+protocol.ContentLengthV0Size], uint64(nn))
+//
+//		c.Lock()
+//
+//		_, err := c.writer.Write(encodedMessage[:])
+//		if err != nil {
+//			c.Unlock()
+//			if c.state.Load() != CONNECTED {
+//				err = c.Error()
+//				c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+//				return n, errors.WithContext(err, WRITE)
+//			}
+//			c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+//			return n, c.closeWithError(err)
+//		}
+//
+//		_, err = c.writer.Write(buf[:nn])
+//		if err != nil {
+//			c.Unlock()
+//			if c.state.Load() != CONNECTED {
+//				err = c.Error()
+//				c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+//				return n, errors.WithContext(err, WRITE)
+//			}
+//			c.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+//			return n, c.closeWithError(err)
+//		}
+//
+//		if len(c.flusher) == 0 {
+//			select {
+//			case c.flusher <- struct{}{}:
+//			default:
+//			}
+//		}
+//
+//		c.Unlock()
+//	}
+//
+//	if errors.Is(err, io.EOF) {
+//		err = nil
+//	}
+//
+//	return
+//}
 
 // WriteMessage takes a frisbee.Message and some (optional) accompanying content, and queues it up to send asynchronously.
 //
@@ -880,85 +881,85 @@ func (s *StreamConn) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// ReadFrom is a function that will send STREAM messages from an io.Reader until EOF or an error occurs
-// In the event that the connection is closed, ReadFrom will return an error.
-func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
-	buf := make([]byte, DefaultBufferSize)
-
-	var encodedMessage [protocol.MessageV0Size]byte
-
-	binary.BigEndian.PutUint16(encodedMessage[protocol.VersionV0Offset:protocol.VersionV0Offset+protocol.VersionV0Size], protocol.Version0)
-	binary.BigEndian.PutUint32(encodedMessage[protocol.IdV0Offset:protocol.IdV0Offset+protocol.IdV0Size], s.id)
-	binary.BigEndian.PutUint32(encodedMessage[protocol.OperationV0Offset:protocol.OperationV0Offset+protocol.OperationV0Size], STREAM)
-
-	s.Logger().Debug().Msgf("StreamConn ReadFrom called")
-
-	for {
-		var nn int
-		if s.state.Load() != CONNECTED {
-			return n, err
-		}
-
-		if s.Closed() {
-			return n, ConnectionClosed
-		}
-		s.Logger().Debug().Msgf("StreamConn ReadFrom READING")
-		nn, err = r.Read(buf)
-		if nn == 0 || err != nil {
-			break
-		}
-
-		s.Logger().Debug().Msgf("ReadFrom ID %d, read %d bytes: %s", s.id, nn, string(buf[:nn]))
-
-		n += int64(nn)
-
-		binary.BigEndian.PutUint64(encodedMessage[protocol.ContentLengthV0Offset:protocol.ContentLengthV0Offset+protocol.ContentLengthV0Size], uint64(nn))
-
-		s.Lock()
-
-		_, err := s.writer.Write(encodedMessage[:])
-		if err != nil {
-			s.Unlock()
-			if s.state.Load() != CONNECTED {
-				err = s.Error()
-				s.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
-				return n, errors.WithContext(err, WRITE)
-			}
-			s.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
-			return n, s.closeWithError(err)
-		}
-
-		_, err = s.writer.Write(buf[:nn])
-		if err != nil {
-			s.Unlock()
-			if s.state.Load() != CONNECTED {
-				err = s.Error()
-				s.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
-				return n, errors.WithContext(err, WRITE)
-			}
-			s.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
-			return n, s.closeWithError(err)
-		}
-
-		if len(s.flusher) == 0 {
-			select {
-			case s.flusher <- struct{}{}:
-			default:
-			}
-		}
-		s.Logger().Debug().Msgf("ReadFrom id %d finished read, looping: %d", s.id, n)
-
-		s.Unlock()
-	}
-
-	if errors.Is(err, io.EOF) {
-		err = nil
-	}
-
-	s.Logger().Debug().Msgf("StreamConn ReadFrom done")
-
-	return
-}
+//// ReadFrom is a function that will send STREAM messages from an io.Reader until EOF or an error occurs
+//// In the event that the connection is closed, ReadFrom will return an error.
+//func (s *StreamConn) ReadFrom(r io.Reader) (n int64, err error) {
+//	buf := make([]byte, DefaultBufferSize)
+//
+//	var encodedMessage [protocol.MessageV0Size]byte
+//
+//	binary.BigEndian.PutUint16(encodedMessage[protocol.VersionV0Offset:protocol.VersionV0Offset+protocol.VersionV0Size], protocol.Version0)
+//	binary.BigEndian.PutUint32(encodedMessage[protocol.IdV0Offset:protocol.IdV0Offset+protocol.IdV0Size], s.id)
+//	binary.BigEndian.PutUint32(encodedMessage[protocol.OperationV0Offset:protocol.OperationV0Offset+protocol.OperationV0Size], STREAM)
+//
+//	s.Logger().Debug().Msgf("StreamConn ReadFrom called")
+//
+//	for {
+//		var nn int
+//		if s.state.Load() != CONNECTED {
+//			return n, err
+//		}
+//
+//		if s.Closed() {
+//			return n, ConnectionClosed
+//		}
+//		s.Logger().Debug().Msgf("StreamConn ReadFrom READING")
+//		nn, err = r.Read(buf)
+//		if nn == 0 || err != nil {
+//			break
+//		}
+//
+//		s.Logger().Debug().Msgf("ReadFrom ID %d, read %d bytes: %s", s.id, nn, string(buf[:nn]))
+//
+//		n += int64(nn)
+//
+//		binary.BigEndian.PutUint64(encodedMessage[protocol.ContentLengthV0Offset:protocol.ContentLengthV0Offset+protocol.ContentLengthV0Size], uint64(nn))
+//
+//		s.Lock()
+//
+//		_, err := s.writer.Write(encodedMessage[:])
+//		if err != nil {
+//			s.Unlock()
+//			if s.state.Load() != CONNECTED {
+//				err = s.Error()
+//				s.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+//				return n, errors.WithContext(err, WRITE)
+//			}
+//			s.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+//			return n, s.closeWithError(err)
+//		}
+//
+//		_, err = s.writer.Write(buf[:nn])
+//		if err != nil {
+//			s.Unlock()
+//			if s.state.Load() != CONNECTED {
+//				err = s.Error()
+//				s.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+//				return n, errors.WithContext(err, WRITE)
+//			}
+//			s.logger.Error().Msgf(errors.WithContext(err, WRITE).Error())
+//			return n, s.closeWithError(err)
+//		}
+//
+//		if len(s.flusher) == 0 {
+//			select {
+//			case s.flusher <- struct{}{}:
+//			default:
+//			}
+//		}
+//		s.Logger().Debug().Msgf("ReadFrom id %d finished read, looping: %d", s.id, n)
+//
+//		s.Unlock()
+//	}
+//
+//	if errors.Is(err, io.EOF) {
+//		err = nil
+//	}
+//
+//	s.Logger().Debug().Msgf("StreamConn ReadFrom done")
+//
+//	return
+//}
 
 // Read is a function that will read buffer messages into a byte slice.
 // In the event that the connection is closed, Read will return an error.

--- a/conn_test.go
+++ b/conn_test.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"net"
 	"testing"
-	"time"
 )
 
 func TestNewConn(t *testing.T) {
@@ -211,7 +210,7 @@ func TestReadClose(t *testing.T) {
 	err = writerConn.Flush()
 	assert.NoError(t, err)
 
-	time.Sleep(time.Second * 5)
+	//time.Sleep(time.Second * 5)
 
 	readMessage, content, err := readerConn.ReadMessage()
 	assert.NoError(t, err)
@@ -266,7 +265,8 @@ func TestWriteClose(t *testing.T) {
 	err = writerConn.conn.Close()
 	assert.NoError(t, err)
 
-	time.Sleep(time.Second * 5)
+	//time.Sleep(time.Second * 5)
+
 	_, _, err = readerConn.ReadMessage()
 	assert.ErrorIs(t, err, ConnectionPaused)
 	assert.ErrorIs(t, readerConn.Error(), ConnectionPaused)
@@ -294,7 +294,7 @@ func TestBufferMessages(t *testing.T) {
 	err = writerConn.Flush()
 	assert.NoError(t, err)
 
-	time.Sleep(time.Second * 5)
+	//time.Sleep(time.Second * 5)
 
 	rawReadMessage := make([]byte, len(rawWriteMessage))
 
@@ -332,7 +332,7 @@ func TestReadFrom(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(rawWriteMessage), n)
 
-	time.Sleep(time.Second * 5)
+	//time.Sleep(time.Second * 5)
 
 	err = writerOne.Close()
 	assert.NoError(t, err)
@@ -378,7 +378,7 @@ func TestWriteTo(t *testing.T) {
 	err = frisbeeWriter.Flush()
 	assert.NoError(t, err)
 
-	time.Sleep(time.Second * 5) // Making sure that the data has propagated into the frisbee reader
+	//time.Sleep(time.Second * 5) // Making sure that the data has propagated into the frisbee reader
 
 	go func() {
 		n, _ := io.Copy(writerOne, frisbeeReader)
@@ -440,7 +440,7 @@ func TestIOCopy(t *testing.T) {
 
 	<-start
 
-	time.Sleep(time.Second * 5)
+	//time.Sleep(time.Second * 5)
 
 	err = frisbeeWriterOne.Close()
 	assert.NoError(t, err)
@@ -486,7 +486,7 @@ func TestStreamConn(t *testing.T) {
 	StreamReaderOne := <-frisbeeReader.StreamConnCh
 	rawReadMessageOne := make([]byte, len(rawWriteMessageOne))
 
-	time.Sleep(time.Second * 5)
+	//time.Sleep(time.Second * 5)
 
 	n, err = StreamReaderOne.Read(rawReadMessageOne)
 	assert.NoError(t, err)
@@ -502,7 +502,7 @@ func TestStreamConn(t *testing.T) {
 	StreamReaderTwo := <-frisbeeReader.StreamConnCh
 	rawReadMessageTwo := make([]byte, len(rawWriteMessageTwo))
 
-	time.Sleep(time.Second * 5)
+	//time.Sleep(time.Second * 5)
 
 	n, err = StreamReaderTwo.Read(rawReadMessageTwo)
 	assert.NoError(t, err)
@@ -513,7 +513,7 @@ func TestStreamConn(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(rawWriteMessageOne), n)
 
-	time.Sleep(time.Second * 5)
+	//time.Sleep(time.Second * 5)
 
 	n, err = StreamReaderOne.Read(rawReadMessageOne)
 	assert.NoError(t, err)
@@ -522,7 +522,7 @@ func TestStreamConn(t *testing.T) {
 
 	StreamWriterOne.Close()
 
-	time.Sleep(time.Second * 5)
+	//time.Sleep(time.Second * 5)
 
 	n, err = StreamReaderOne.Read(rawReadMessageOne)
 	assert.Error(t, err)
@@ -532,7 +532,7 @@ func TestStreamConn(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(rawWriteMessageTwo), n)
 
-	time.Sleep(time.Second * 5)
+	//time.Sleep(time.Second * 5)
 
 	n, err = StreamReaderTwo.Read(rawReadMessageTwo)
 	assert.NoError(t, err)

--- a/conn_test.go
+++ b/conn_test.go
@@ -493,8 +493,6 @@ func TestStreamConn(t *testing.T) {
 	StreamReaderOne := <-frisbeeReader.StreamConnCh
 	rawReadMessageOne := make([]byte, len(rawWriteMessageOne))
 
-	//time.Sleep(time.Second * 5)
-
 	n, err = StreamReaderOne.Read(rawReadMessageOne)
 	assert.NoError(t, err)
 	assert.Equal(t, len(rawWriteMessageOne), n)
@@ -509,8 +507,6 @@ func TestStreamConn(t *testing.T) {
 	StreamReaderTwo := <-frisbeeReader.StreamConnCh
 	rawReadMessageTwo := make([]byte, len(rawWriteMessageTwo))
 
-	//time.Sleep(time.Second * 5)
-
 	n, err = StreamReaderTwo.Read(rawReadMessageTwo)
 	assert.NoError(t, err)
 	assert.Equal(t, len(rawWriteMessageTwo), n)
@@ -520,8 +516,6 @@ func TestStreamConn(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(rawWriteMessageOne), n)
 
-	//time.Sleep(time.Second * 5)
-
 	n, err = StreamReaderOne.Read(rawReadMessageOne)
 	assert.NoError(t, err)
 	assert.Equal(t, len(rawWriteMessageOne), n)
@@ -530,8 +524,6 @@ func TestStreamConn(t *testing.T) {
 	err = StreamWriterOne.Close()
 	assert.NoError(t, err)
 
-	//time.Sleep(time.Second * 5)
-
 	n, err = StreamReaderOne.Read(rawReadMessageOne)
 	assert.Error(t, err)
 	assert.Equal(t, 0, n)
@@ -539,8 +531,6 @@ func TestStreamConn(t *testing.T) {
 	n, err = StreamWriterTwo.Write(rawWriteMessageTwo)
 	assert.NoError(t, err)
 	assert.Equal(t, len(rawWriteMessageTwo), n)
-
-	//time.Sleep(time.Second * 5)
 
 	n, err = StreamReaderTwo.Read(rawReadMessageTwo)
 	assert.NoError(t, err)

--- a/conn_test.go
+++ b/conn_test.go
@@ -486,6 +486,8 @@ func TestStreamConn(t *testing.T) {
 	StreamReaderOne := <-frisbeeReader.StreamConnCh
 	rawReadMessageOne := make([]byte, len(rawWriteMessageOne))
 
+	time.Sleep(time.Second * 5)
+
 	n, err = StreamReaderOne.Read(rawReadMessageOne)
 	assert.NoError(t, err)
 	assert.Equal(t, len(rawWriteMessageOne), n)
@@ -499,6 +501,8 @@ func TestStreamConn(t *testing.T) {
 
 	StreamReaderTwo := <-frisbeeReader.StreamConnCh
 	rawReadMessageTwo := make([]byte, len(rawWriteMessageTwo))
+
+	time.Sleep(time.Second * 5)
 
 	n, err = StreamReaderTwo.Read(rawReadMessageTwo)
 	assert.NoError(t, err)

--- a/frisbee.go
+++ b/frisbee.go
@@ -93,8 +93,8 @@ const (
 	// HEARTBEAT is used to send heartbeats from the client to the server (and measure round trip time)
 	HEARTBEAT = uint32(iota)
 	BUFFER
-	RESERVED2
-	RESERVED3
+	STREAM
+	STREAMCLOSE
 	RESERVED4
 	RESERVED5
 	RESERVED6

--- a/frisbee.go
+++ b/frisbee.go
@@ -92,7 +92,6 @@ const (
 const (
 	// HEARTBEAT is used to send heartbeats from the client to the server (and measure round trip time)
 	HEARTBEAT = uint32(iota)
-	BUFFER
 	STREAM
 	STREAMCLOSE
 	RESERVED4

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -33,9 +33,9 @@ var (
 )
 
 const (
-	MessagePing   = uint32(0x0003) // PING
-	MessagePong   = uint32(0x0004) // PONG
-	MessagePacket = uint32(0x0005) // PACKET
+	MessagePing   = uint32(10) // PING
+	MessagePong   = uint32(11) // PONG
+	MessagePacket = uint32(12) // PACKET
 )
 
 const (


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue has been fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Adds stream multiplexing into frisbee, allowing for multiple raw streams of data underlying the same frisbee connection.

Fixes LOOP-106

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] New feature (non-breaking change which adds functionality) [title: 'feat:']
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing

Please make sure that existing test cases pass (with `go test ./... -race` and `go test -bench=. ./... -race`), 
and if required please add new test cases and list them below:

New Test:
- [x] TestStreamConn
- [x] TestStreamMessages

Updated Tests:
- [x] TestReadFrom
- [x] TestWriteTo
- [x] TestIOCopy

## Benchmarking

Frisbee tries to adhere to strict performance requirements, so please make sure to run `go test -bench=. ./...` and paste the results below:

### Benchmarking Results:

```shell
goos: darwin
goarch: amd64
pkg: github.com/loophole-labs/frisbee
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkClientThroughput/test-16                     36          30441591 ns/op
BenchmarkClientThroughputResponse/test-16                     38          30919325 ns/op
BenchmarkThroughputPipe32-16                                  45          23647008 ns/op
BenchmarkThroughputPipe512-16                                 31          37223619 ns/op
BenchmarkThroughputNetwork32-16                               50          21312556 ns/op
BenchmarkThroughputNetwork512-16                              33          32507995 ns/op
BenchmarkThroughputNetwork1024-16                             25          46671548 ns/op
BenchmarkThroughputNetwork2048-16                             15          77521268 ns/op
BenchmarkThroughputNetwork4096-16                              8         134677739 ns/op
BenchmarkThroughputNetwork1mb-16                             358           3221628 ns/op
BenchmarkThroughput/test-16                                   33          34900274 ns/op
BenchmarkThroughputWithResponse/test-16                       34          34914097 ns/op
PASS
ok      github.com/loophole-labs/frisbee        23.033s
?       github.com/loophole-labs/frisbee/internal/errors        [no test files]
goos: darwin
goarch: amd64
pkg: github.com/loophole-labs/frisbee/internal/protocol
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkEncodeHandler-16               71007698                14.68 ns/op
BenchmarkDecodeHandler-16               100000000               10.85 ns/op
BenchmarkEncodeDecodeHandler-16         37778564                28.04 ns/op
BenchmarkEncode-16                      85960918                14.00 ns/op
BenchmarkDecode-16                      160845126                7.596 ns/op
BenchmarkEncodeDecode-16                41213019                26.76 ns/op
PASS
ok      github.com/loophole-labs/frisbee/internal/protocol      7.761s
PASS
ok      github.com/loophole-labs/frisbee/internal/ringbuffer    0.146s
```

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `go fmt ./...` has been run
- [x] `golangci-lint run --skip-dirs-use-default` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
